### PR TITLE
Modified to ignore searching property if bSearchable is set to false on ...

### DIFF
--- a/DataTablesParser/DatatablesParser.cs
+++ b/DataTablesParser/DatatablesParser.cs
@@ -34,7 +34,9 @@ namespace DataTablesParser
         * string: sEcho - Information for DataTables to use for rendering
          */
 
+        private const string INDIVIDUAL_DATA_KEY_PREFIX = "mDataProp_";
         private const string INDIVIDUAL_SEARCH_KEY_PREFIX = "sSearch_";
+        private const string INDIVIDUAL_SEARCHABLE_KEY_PREFIX = "bSearchable_";
         private const string INDIVIDUAL_SORT_KEY_PREFIX = "iSortCol_";
         private const string INDIVIDUAL_SORT_DIRECTION_KEY_PREFIX = "sSortDir_";
         private const string DISPLAY_START = "iDisplayStart";
@@ -45,9 +47,9 @@ namespace DataTablesParser
         private IQueryable<T> _queriable;
         private readonly HttpRequestBase _httpRequest;
         private readonly Type _type;
-        private  PropertyInfo[] _properties;
+        private PropertyInfo[] _properties;
 
-		public DataTablesParser(HttpRequestBase httpRequest, IQueryable<T> queriable)
+        public DataTablesParser(HttpRequestBase httpRequest, IQueryable<T> queriable)
         {
             _queriable = queriable;
             _httpRequest = httpRequest;
@@ -55,7 +57,7 @@ namespace DataTablesParser
             _properties = _type.GetProperties();
         }
 
-		public DataTablesParser(HttpRequest httpRequest, IQueryable<T> queriable)
+        public DataTablesParser(HttpRequest httpRequest, IQueryable<T> queriable)
             : this(new HttpRequestWrapper(httpRequest), queriable)
         { }
 
@@ -64,7 +66,7 @@ namespace DataTablesParser
         /// DataTable request values
         /// </summary>
         /// <returns>Formated output for DataTables, which should be serialized to JSON</returns>
-       
+
         public FormatedList<T> Parse()
         {
             var list = new FormatedList<T>();
@@ -76,8 +78,8 @@ namespace DataTablesParser
             list.sEcho = int.Parse(_httpRequest[ECHO]);
 
             // count the record BEFORE filtering
-            list.iTotalRecords =  _queriable.Count();
-           
+            list.iTotalRecords = _queriable.Count();
+
             // apply the sort, if there is one
             ApplySort();
 
@@ -90,13 +92,13 @@ namespace DataTablesParser
             Func<T, bool> GenericFind = delegate(T item)
             {
                 bool bFound = false;
-                var sSearch = _httpRequest["sSearch"]; 
+                var sSearch = _httpRequest["sSearch"];
 
-                if(string.IsNullOrWhiteSpace(sSearch))
+                if (string.IsNullOrWhiteSpace(sSearch))
                 {
                     return true;
                 }
-    
+
                 foreach (PropertyInfo property in _properties)
                 {
                     if (Convert.ToString(property.GetValue(item, null)).ToLower().Contains((sSearch).ToLower()))
@@ -110,7 +112,7 @@ namespace DataTablesParser
 
             //Test ofr linq to entities
             //Anyone know of a better way to do this test??
-            if (_queriable is ObjectQuery<T> || _queriable is DbQuery<T> ) 
+            if (_queriable is ObjectQuery<T> || _queriable is DbQuery<T>)
             {
 
                 // setup the data with individual property search, all fields search,
@@ -144,20 +146,20 @@ namespace DataTablesParser
                 list.iTotalDisplayRecords = _queriable.Count(GenericFind);
             }
 
-   
+
 
             return list;
         }
 
         public async Task<FormatedList<T>> ParseAsync()
         {
-          return  await Task.Run(() =>
-                        {
-                            return Parse();
-                        });
-           
+            return await Task.Run(() =>
+                          {
+                              return Parse();
+                          });
+
         }
-     
+
 
         private void ApplySort()
         {
@@ -177,42 +179,42 @@ namespace DataTablesParser
                 string sortdir = _httpRequest[INDIVIDUAL_SORT_DIRECTION_KEY_PREFIX + key.Replace(INDIVIDUAL_SORT_KEY_PREFIX, string.Empty)];
 
                 // form the sortation per property via a property expression
-                
+
                 //var expression = Expression.Convert(Expression.Property(paramExpr, _properties[sortcolumn].Name),typeof(object));
-                 var expression1 = Expression.Property(paramExpr, _properties[sortcolumn].Name);
-                var propType =  _properties[sortcolumn].PropertyType;
+                var expression1 = Expression.Property(paramExpr, _properties[sortcolumn].Name);
+                var propType = _properties[sortcolumn].PropertyType;
                 var delegateType = Expression.GetFuncType(typeof(T), propType);
                 var propertyExpr = Expression.Lambda(delegateType, expression1, paramExpr);
                 //var propertyExpr = Expression.Lambda<Func<T, dynamic>>(Expression.Property(paramExpr, _properties[sortcolumn].Name), paramExpr);
-               
-               
+
+
                 // apply the sort (default is ascending if not specified)
                 if (string.IsNullOrEmpty(sortdir) || sortdir.Equals(ASCENDING_SORT, StringComparison.OrdinalIgnoreCase))
                     //_queriable = _queriable.OrderBy<T, dynamic>(propertyExpr);
-                    
-        _queriable = typeof(Queryable).GetMethods().Single(
-            method => method.Name == (thenBy ? "ThenBy" : "OrderBy")
-                        && method.IsGenericMethodDefinition
-                        && method.GetGenericArguments().Length == 2
-                        && method.GetParameters().Length == 2)
-                .MakeGenericMethod(typeof(T), propType)
-                .Invoke(null, new object[] { _queriable, propertyExpr }) as IOrderedQueryable<T>;
-    
+
+                    _queriable = typeof(Queryable).GetMethods().Single(
+                        method => method.Name == (thenBy ? "ThenBy" : "OrderBy")
+                                    && method.IsGenericMethodDefinition
+                                    && method.GetGenericArguments().Length == 2
+                                    && method.GetParameters().Length == 2)
+                            .MakeGenericMethod(typeof(T), propType)
+                            .Invoke(null, new object[] { _queriable, propertyExpr }) as IOrderedQueryable<T>;
+
                 else
                     //_queriable = _queriable.OrderByDescending<T, dynamic>(propertyExpr);
 
-                _queriable = typeof(Queryable).GetMethods().Single(
-        method => method.Name == (thenBy ? "ThenByDescending" : "OrderByDescending")
-                && method.IsGenericMethodDefinition
-                && method.GetGenericArguments().Length == 2
-                && method.GetParameters().Length == 2)
-        .MakeGenericMethod(typeof(T), propType)
-        .Invoke(null, new object[] { _queriable, propertyExpr }) as IOrderedQueryable<T>;
+                    _queriable = typeof(Queryable).GetMethods().Single(
+            method => method.Name == (thenBy ? "ThenByDescending" : "OrderByDescending")
+                    && method.IsGenericMethodDefinition
+                    && method.GetGenericArguments().Length == 2
+                    && method.GetParameters().Length == 2)
+            .MakeGenericMethod(typeof(T), propType)
+            .Invoke(null, new object[] { _queriable, propertyExpr }) as IOrderedQueryable<T>;
 
                 thenBy = true;
             }
 
-			//Linq to entities needs a sort to implement skip
+            //Linq to entities needs a sort to implement skip
             if (!thenBy && !(_queriable is IOrderedQueryable<T>))
             {
                 var firstProp = Expression.Property(paramExpr, _properties[0].Name);
@@ -280,15 +282,15 @@ namespace DataTablesParser
 
                     // val.{PropertyName}.ToString().ToLower().Contains({query})
                     var toStringCall = Expression.Call(
-                                        Expression.Call(
+                        Expression.Call(
                                             Expression.Property(paramExpr, _properties[property]), "ToString", new Type[0]),
-                                        typeof(string).GetMethod("ToLower", new Type[0]));
+                        typeof(string).GetMethod("ToLower", new Type[0]));
 
                     // reset where expression to also require the current contraint
                     whereExpr = Expression.And(whereExpr,
-                                               Expression.Call(toStringCall,
-                                                               typeof(string).GetMethod("Contains"),
-                                                               Expression.Constant(query)));
+                        Expression.Call(toStringCall,
+                            typeof(string).GetMethod("Contains"),
+                            Expression.Constant(query)));
 
                 }
 
@@ -315,9 +317,35 @@ namespace DataTablesParser
 
                 List<MethodCallExpression> searchProps = new List<MethodCallExpression>();
 
+                var dataNumbers = new Dictionary<int, string>();
+
+                foreach (string key in _httpRequest.Params.AllKeys.Where(x => x.StartsWith(INDIVIDUAL_DATA_KEY_PREFIX)))
+                {
+                    // parse the property number
+                    var property = -1;
+
+                    var propertyString = key.Replace(INDIVIDUAL_DATA_KEY_PREFIX, string.Empty);
+
+                    if ((!int.TryParse(propertyString, out property))
+                        || property >= _properties.Length || string.IsNullOrEmpty(key))
+                        break; // ignore if the option is invalid
+
+                    dataNumbers.Add(property, _httpRequest[key]);
+                }
+
                 foreach (var prop in _properties)
                 {
-                    if(!prop.CanWrite){ continue; }
+                    var searchable = INDIVIDUAL_SEARCHABLE_KEY_PREFIX
+                                     + dataNumbers.Where(d => d.Value == prop.Name).Select(d => d.Key).FirstOrDefault();
+
+                    bool isSearchable;
+
+                    bool.TryParse(_httpRequest[searchable], out isSearchable);
+
+                    if (!prop.CanWrite || !isSearchable)
+                    {
+                        continue;
+                    }
 
                     Expression stringProp = null;
 
@@ -327,18 +355,20 @@ namespace DataTablesParser
                     {
                         var toDoubleCall = Expression.Convert(propExp, typeof(Nullable<double>));
 
-                        var doubleConvert = typeof(SqlFunctions).GetMethod("StringConvert", new Type[] { typeof(Nullable<double>) });
+                        var doubleConvert = typeof(SqlFunctions).GetMethod(
+                            "StringConvert", new Type[] { typeof(Nullable<double>) });
 
                         stringProp = Expression.Call(doubleConvert, toDoubleCall);
 
                     }
 
 
-                    if ( prop.PropertyType == typeof(decimal))
+                    if (prop.PropertyType == typeof(decimal))
                     {
                         var toDecimalCall = Expression.Convert(propExp, typeof(Nullable<decimal>));
 
-                        var decimalConvert = typeof(SqlFunctions).GetMethod("StringConvert", new Type[] { typeof(Nullable<decimal>) });
+                        var decimalConvert = typeof(SqlFunctions).GetMethod(
+                            "StringConvert", new Type[] { typeof(Nullable<decimal>) });
 
                         stringProp = Expression.Call(decimalConvert, toDecimalCall);
                     }
@@ -349,24 +379,29 @@ namespace DataTablesParser
 
                         var date = Expression.Convert(propExp, typeof(Nullable<DateTime>));
                         //Only way to get a number for date part
-                        var datePart = typeof(SqlFunctions).GetMethod("DatePart", new Type[] { typeof(string), typeof(Nullable<DateTime>) });
+                        var datePart = typeof(SqlFunctions).GetMethod(
+                            "DatePart", new Type[] { typeof(string), typeof(Nullable<DateTime>) });
                         //get day of month and year which are already strings
-                        var dateName = typeof(SqlFunctions).GetMethod("DateName", new Type[] { typeof(string), typeof(Nullable<DateTime>) });
+                        var dateName = typeof(SqlFunctions).GetMethod(
+                            "DateName", new Type[] { typeof(string), typeof(Nullable<DateTime>) });
                         //Call to get month part
                         var month = Expression.Call(datePart, Expression.Constant("m"), date);
                         //Convert to double
                         var toDouble = Expression.Convert(month, typeof(Nullable<double>));
                         //convert to string
-                        var monthPartToString = typeof(SqlFunctions).GetMethod("StringConvert", new Type[] { typeof(Nullable<double>) });
+                        var monthPartToString = typeof(SqlFunctions).GetMethod(
+                            "StringConvert", new Type[] { typeof(Nullable<double>) });
                         //now all three numerical parts of date as string
                         var monthPart = Expression.Call(monthPartToString, toDouble);
                         var dayPart = Expression.Call(dateName, Expression.Constant("d"), date);
                         var yearPart = Expression.Call(dateName, Expression.Constant("yy"), date);
-                        var conCat4 = typeof(string).GetMethod("Concat", new Type[] { typeof(string), typeof(string), typeof(string), typeof(string) });
-                        var conCat2 = typeof(string).GetMethod("Concat", new Type[] { typeof(string), typeof(string) });
+                        var conCat4 = typeof(string).GetMethod(
+                            "Concat", new Type[] { typeof(string), typeof(string), typeof(string), typeof(string) });
+                        var conCat2 = typeof(string).GetMethod(
+                            "Concat", new Type[] { typeof(string), typeof(string) });
                         var delim = Expression.Constant("/");
-                        stringProp = Expression.Call(conCat2,
-                                                        Expression.Call(conCat4, monthPart, delim, dayPart, delim), yearPart);
+                        stringProp = Expression.Call(
+                            conCat2, Expression.Call(conCat4, monthPart, delim, dayPart, delim), yearPart);
 
                     }
 
@@ -377,16 +412,16 @@ namespace DataTablesParser
 
                     if (stringProp != null)
                     {
-                        searchProps.Add(Expression.Call(stringProp, typeof(string).GetMethod("Contains"), searchExpression));
+                        searchProps.Add(
+                            Expression.Call(stringProp, typeof(string).GetMethod("Contains"), searchExpression));
                     }
-
                 }
-  
+
                 var propertyQuery = searchProps.ToArray();
                 // we now need to compound the expression by starting with the first
                 // expression and build through the iterator
                 Expression compoundExpression = propertyQuery[0];
-               
+
                 // add the other expressions
                 for (int i = 1; i < propertyQuery.Length; i++)
                     compoundExpression = Expression.Or(compoundExpression, propertyQuery[i]);


### PR DESCRIPTION
...client.

Hi there. I'm testing out DataTables and I came across your parser. I noticed that it wasn't doing anything with bSearchable so I added the functionality.

I added this as when searching on numbers the records with matching Id's (not visible) to the user were being returned.
