### PR TITLE
Update DatatablesParser.cs

### DIFF
--- a/src/DatatablesParser/DatatablesParser.cs
+++ b/src/DatatablesParser/DatatablesParser.cs
@@ -323,7 +323,7 @@ namespace DataTablesParser
 
                     if(globalFilterConst!=null)
                     {
-                        var globalTest = Expression.Call(toLower, typeof(string).GetMethod("Contains"), globalFilterConst);
+                        var globalTest = Expression.Call(toLower, typeof(string).GetMethod("Contains", new[] { typeof(string) }), globalFilterConst);
 
                         if(filterExpr == null)
                         {
@@ -337,7 +337,7 @@ namespace DataTablesParser
 
                     if(individualFilterConst!=null)
                     {
-                        individualConditions.Add(Expression.Call(toLower, typeof(string).GetMethod("Contains"), individualFilterConst));
+                        individualConditions.Add(Expression.Call(toLower, typeof(string).GetMethod("Contains", new[] { typeof(string) }), individualFilterConst));
 
                     }
 


### PR DESCRIPTION
I was getting a System.Reflection.AmbiguousMatchException: 'Ambiguous match found.' on the "Contains" method which has multiple signatures. Adding in new[] { typeof(string) } specifies the right method, I believe.

First pull request and contribution.

Thanks. Nice work.