### PR TITLE
Fix translation in bitwise operators and check if null before tolower call

### DIFF
--- a/src/DatatablesParser/DatatablesParser.cs
+++ b/src/DatatablesParser/DatatablesParser.cs
@@ -361,14 +361,6 @@ namespace DataTablesParser
                     {
                         Expression globalTest = Expression.Call(toLower, typeof(string).GetMethod(globalFilterFn, new[] { typeof(string) }), globalFilterConst);
 
-                        // Check if it is nullable
-                        var defValue = prop.PropertyType.GetTypeInfo().IsValueType ? Activator.CreateInstance(prop.PropertyType) : null;
-                        if (defValue == null)
-                        {
-                            var isNotNull = Expression.NotEqual(Expression.Property(paramExpression, prop), Expression.Constant(null));
-                            globalTest = Expression.AndAlso(isNotNull, globalTest);
-                        }
-
                         if(filterExpr == null)
                         {
                             filterExpr = globalTest;

--- a/src/DatatablesParser/DatatablesParser.cs
+++ b/src/DatatablesParser/DatatablesParser.cs
@@ -359,7 +359,15 @@ namespace DataTablesParser
 
                     if(globalFilterConst!=null)
                     {
-                        var globalTest = Expression.Call(toLower, typeof(string).GetMethod(globalFilterFn, new[] { typeof(string) }), globalFilterConst);
+                        Expression globalTest = Expression.Call(toLower, typeof(string).GetMethod(globalFilterFn, new[] { typeof(string) }), globalFilterConst);
+
+                        // Check if it is nullable
+                        var defValue = prop.PropertyType.GetTypeInfo().IsValueType ? Activator.CreateInstance(prop.PropertyType) : null;
+                        if (defValue == null)
+                        {
+                            var isNotNull = Expression.NotEqual(Expression.Property(paramExpression, prop), Expression.Constant(null));
+                            globalTest = Expression.AndAlso(isNotNull, globalTest);
+                        }
 
                         if(filterExpr == null)
                         {
@@ -367,7 +375,7 @@ namespace DataTablesParser
                         }
                         else
                         {
-                            filterExpr = Expression.Or(filterExpr,globalTest);
+                            filterExpr = Expression.OrElse(filterExpr,globalTest);
                         }
                     }
 

--- a/test/DatatablesParser.Tests/MysqlEntityTests.cs
+++ b/test/DatatablesParser.Tests/MysqlEntityTests.cs
@@ -128,7 +128,26 @@ namespace DataTablesParser.Tests
 
         }
 
+        [Fact]
+        public void ResultsWhenSearchInNullColumnTest()
+        {
+            var context = TestHelper.GetMysqlContext();
+            var p = TestHelper.CreateParams();
+            var displayLength = 1;
 
+
+            //Set filter parameter
+            p[Constants.SEARCH_KEY] = new StringValues("Xorie");
+
+            var parser = new Parser<Person>(p, context.People);
+
+            var result = parser.Parse().recordsFiltered;
+
+            Console.WriteLine("MySql - Search one row whe some columns are null: {0}", result);
+
+            Assert.Equal(displayLength, result);
+
+        }
 
     }
 }

--- a/test/DatatablesParser.Tests/TestHelper.cs
+++ b/test/DatatablesParser.Tests/TestHelper.cs
@@ -62,7 +62,7 @@ namespace DataTablesParser.Tests
             new Person
             {
                 FirstName = "Xorie",
-                LastName = "Zera",
+                LastName = null, // "Zera", for search in null column test
                 BirthDate = DateTime.Parse("10/3/1974"),
                 Children = 2,
                 height = 5.9M,


### PR DESCRIPTION
Hi Garvin,

I think I have fixed a problem in GenerateEntityFilter that appears with MySql (I'm using Pomelo provider).

When I use a nullable column with some NULL values the translated LOWER(column) fail and the row is skipped by MySql.

I've added a null check in AND to skip the LOWER call.

```csharp
// Check if it is nullable
var defValue = prop.PropertyType.GetTypeInfo().IsValueType ? Activator.CreateInstance(prop.PropertyType) : null;
if (defValue == null)
{
    var isNotNull = Expression.NotEqual(Expression.Property(paramExpression, prop), Expression.Constant(null));
    globalTest = Expression.And(isNotNull, globalTest);
}
```

So from this:

```sql
| (LOCATE(CONVERT('search' USING utf8mb4) COLLATE utf8mb4_bin, LOWER(`u`.`user`)) > 0))
```

now it traslates in:

```sql
 | (`u`.`user` IS NOT NULL & (LOCATE(CONVERT('search' USING utf8mb4) COLLATE utf8mb4_bin, LOWER(`u`.`user`)) > 0)))
```

But this fail because of the **BITWISE AND** from Expression.And.
So I changed my Expression.And into Expression.AndAlso and your Expression.Or to Expression.OrElse, too.

Final translation is:

```sql
 OR (`u`.`user` IS NOT NULL AND (LOCATE(CONVERT('search' USING utf8mb4) COLLATE utf8mb4_bin, LOWER(`u`.`user`)) > 0)))
```

I hope I haven't created bugs and you could merge it.