### PR TITLE
Perform extra filters on IQueryable maintaning Total Count

### DIFF
--- a/test/DatatablesParser.Tests/MysqlEntityTests.cs
+++ b/test/DatatablesParser.Tests/MysqlEntityTests.cs
@@ -127,5 +127,28 @@ namespace DataTablesParser.Tests
 
         }
 
+        [Fact]
+        public void AddCustomFilterTest()
+        {
+            var context = TestHelper.GetMysqlContext();
+            var p = TestHelper.CreateParams();
+            var displayLength = 2; // James and Tony
+
+
+            var parser = new Parser<Person>(p, context.People); // p is empty, all rows
+
+            var minDate = DateTime.Parse("1960-01-01");
+            var maxDate = DateTime.Parse("1970-01-01");
+            parser.AddCustomFilter(x => x.BirthDate >= minDate);
+            parser.AddCustomFilter(x => x.BirthDate < maxDate);
+
+            var result = parser.Parse().recordsFiltered;
+
+            Console.WriteLine("MySql - Search only born between 1960 and 1970: {0}", result);
+
+            Assert.Equal(displayLength, result);
+
+        }
+
     }
 }


### PR DESCRIPTION
Added Parser.AddCustomFilter to perform extra filters on IQueryable maintaning Total Count.

If I perfom `query = query.Where(...)` before creating the Parser these filters are not counted as filtered rows but as total amount of rows.

Example:

```csharp
public IActionResult Data(DateTime? from, DateTime? to)
{
    var query = _context.Apps.AsQueryable();

    var parser = new Parser<WeldpayApplication>(Request.Form, query);

    if (from.HasValue)
        parser.AddCustomFilter(x => x.created >= from.Value);

    if (to.HasValue)
        parser.AddCustomFilter(x => x.created <= to.Value);

    return Json(parser.Parse(), new JsonSerializerSettings { NullValueHandling = NullValueHandling.Include, Formatting = Formatting.None });
}
```