### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/test/DatatablesParser.Tests/DatatablesParser.Tests.csproj
+++ b/test/DatatablesParser.Tests/DatatablesParser.Tests.csproj
@@ -8,12 +8,12 @@
     <ProjectReference Include="../../src/DatatablesParser/DatatablesParser.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.6" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.1" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi@garvincasimir, I found an issue in the DatatablesParser.Tests.csproj:

Packages Microsoft.EntityFrameworkCore.InMemory v3.1.3, Microsoft.EntityFrameworkCore.SqlServer v3.1.1,Pomelo.EntityFrameworkCore.MySql v3.1.1, Microsoft.NET.Test.Sdk v15.3.0, xunit v2.2.0 and xunit.runner.visualstudio v2.2.0 transitively introduce 122 dependencies into csharp-datatables-parser’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/csharp-datatables-parser.html)), while Microsoft.EntityFrameworkCore.InMemory v3.1.4, Microsoft.EntityFrameworkCore.SqlServer v3.1.6,Pomelo.EntityFrameworkCore.MySql v3.2.1, Microsoft.NET.Test.Sdk v15.5.0, xunit v2.3.0 and xunit.runner.visualstudio v2.3.1 can only introduce 93 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/csharp-datatables-parser_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose